### PR TITLE
Rename Services CPT to Logos CPT

### DIFF
--- a/ls-custom-post-types/ls-cpt-logos.php
+++ b/ls-custom-post-types/ls-cpt-logos.php
@@ -1,28 +1,28 @@
 <?php
 /**
- * Register a custom post type called "Services".
+ * Register a custom post type called "Logos".
  */
-function lemonade_create_services() {
+function ls_create_logos() {
 	$labels = array(
-		'name'                => 'Services',
-		'singular_name'       => 'Service',
-		'add_new'             => 'Add Service',
-		'all_items'           => 'All Services',
-		'add_new_item'        => 'Add New Service',
-		'edit_item'           => 'Edit Service',
-		'new_item'	          => 'New Service',
-		'view_item'           => 'View Service',
-		'search_items'        => 'Search Services',
-		'not_found'           => 'No Services found',
-		'not_found_in_trash'  => 'No Services found in Trash',
-		'parent_item_colon'   => 'Parent Service:',
-		'menu_name'           => 'Services',
-		'update_item'         => 'Update Service',	
+		'name'                => 'Logos',
+		'singular_name'       => 'Logo',
+		'add_new'             => 'Add Logo',
+		'all_items'           => 'All Logos',
+		'add_new_item'        => 'Add New Logo',
+		'edit_item'           => 'Edit Logo',
+		'new_item'	          => 'New Logo',
+		'view_item'           => 'View Logo',
+		'search_items'        => 'Search Logos',
+		'not_found'           => 'No Logos found',
+		'not_found_in_trash'  => 'No Logos found in Trash',
+		'parent_item_colon'   => 'Parent Logo:',
+		'menu_name'           => 'Logos',
+		'update_item'         => 'Update Logo',	
 	);
 
 	$args = array(
-		'label'               => 'Services',
-		'description'         => 'Services post type',
+		'label'               => 'Logos',
+		'description'         => 'Logo post type',
 		'labels'              => $labels,
 		'public'              => true,
 		'has_archive'         => true,
@@ -32,7 +32,7 @@ function lemonade_create_services() {
 		'capability_type'	  => 'post',	
 		'hierarchical'        => false,	
 		'supports'            => array( 'title', 'excerpt', 'thumbnail', 'revisions', 'page-attributes', 'editor'),
-		'taxonomies'		  => array('service_type'),
+		'taxonomies'		  => array('logo_type'),
 		'menu_position'       => 6,
 		'exclude_from_search' => false,
 		'show_ui'             => true,
@@ -41,31 +41,31 @@ function lemonade_create_services() {
 		'show_in_admin_bar'   => true,
 		'can_export'          => true,
 		'show_in_rest'		  => true,	
-		'menu_icon' => 'dashicons-clipboard',
+		'menu_icon' => 'dashicons-images-alt',
 	);
 
-	register_post_type( 'services', $args );
+	register_post_type( 'logos', $args );
 }
-add_action( 'init', 'lemonade_create_services', 0 );
+add_action( 'init', 'ls_create_logos', 0 );
 
 
 /**
- * Register a custom taxonomy for the Services CPT.
+ * Register a custom taxonomy for the Logos CPT.
  */
-function create_service_taxonomies() {
+function ls_create_logo_taxonomies() {
 	// Add new taxonomy, make it hierarchical (like categories)
 	$labels = array(
-		'name'              => _x( 'Service Categories', 'taxonomy general name', 'textdomain' ),
-		'singular_name'     => _x( 'Service Category', 'taxonomy singular name', 'textdomain' ),
-		'search_items'      => __( 'Search Service Categories', 'textdomain' ),
-		'all_items'         => __( 'All Service Categories', 'textdomain' ),
-		'parent_item'       => __( 'Parent Service Category', 'textdomain' ),
-		'parent_item_colon' => __( 'Parent Service Category:', 'textdomain' ),
-		'edit_item'         => __( 'Edit Service Category', 'textdomain' ),
-		'update_item'       => __( 'Update Service Category', 'textdomain' ),
-		'add_new_item'      => __( 'Add New Service Category', 'textdomain' ),
-		'new_item_name'     => __( 'New Service Category Name', 'textdomain' ),
-		'menu_name'         => __( 'Service Category', 'textdomain' ),
+		'name'              => _x( 'Logo Categories', 'taxonomy general name', 'textdomain' ),
+		'singular_name'     => _x( 'Logo Category', 'taxonomy singular name', 'textdomain' ),
+		'search_items'      => __( 'Search Logo Categories', 'textdomain' ),
+		'all_items'         => __( 'All Logo Categories', 'textdomain' ),
+		'parent_item'       => __( 'Parent Logo Category', 'textdomain' ),
+		'parent_item_colon' => __( 'Parent Logo Category:', 'textdomain' ),
+		'edit_item'         => __( 'Edit Logo Category', 'textdomain' ),
+		'update_item'       => __( 'Update Logo Category', 'textdomain' ),
+		'add_new_item'      => __( 'Add New Logo Category', 'textdomain' ),
+		'new_item_name'     => __( 'New Logo Category Name', 'textdomain' ),
+		'menu_name'         => __( 'Logo Category', 'textdomain' ),
 	);
 
 	$args = array(
@@ -74,14 +74,14 @@ function create_service_taxonomies() {
 		'show_ui'           => true,
 		'show_admin_column' => true,
 		'query_var'         => true,
-		'rewrite'           => array( 'slug' => 'service_category' ),
+		'rewrite'           => array( 'slug' => 'logo_category' ),
 		'show_in_rest' => true,
 	);
 
-	register_taxonomy( 'service_category', array( 'services' ), $args );
+	register_taxonomy( 'logo_category', array( 'logos' ), $args );
 }
-add_action( 'init', 'create_service_taxonomies', 0 );
+add_action( 'init', 'ls_create_logo_taxonomies', 0 );
 
 add_action( 'init', function () {
-	add_ux_builder_post_type( 'services' );
+	add_ux_builder_post_type( 'logos' );
 } );


### PR DESCRIPTION
Renamed all instances of 'Service(s)' to 'Logo(s)' when registering the custom post type as well as the custom taxonomy. 